### PR TITLE
Fix arm64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x1657198823e52a61 
 RUN apt-get update && apt-get install -y zerotier-one=1.6.5
 COPY main.sh /var/lib/zerotier-one/main.sh
 
-FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.32
+FROM alpine:3.14
 
 LABEL version="1.6.5"
 LABEL description="Containerized ZeroTier One for use on CoreOS or other Docker-only Linux hosts."

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:buster-slim as builder
 ## Supports x86_64, x86, arm, and arm64
 
 RUN apt-get update && apt-get install -y curl gnupg
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0x1657198823e52a61  && \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x1657198823e52a61  && \
     echo "deb http://download.zerotier.com/debian/buster buster main" > /etc/apt/sources.list.d/zerotier.list
 RUN apt-get update && apt-get install -y zerotier-one=1.6.5
 COPY main.sh /var/lib/zerotier-one/main.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:buster-slim as builder
 
 RUN apt-get update && apt-get install -y curl gnupg
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x1657198823e52a61  && \
-    echo "deb http://download.zerotier.com/debian/buster buster main" > /etc/apt/sources.list.d/zerotier.list
+    echo "deb https://download.zerotier.com/debian/buster buster main" > /etc/apt/sources.list.d/zerotier.list
 RUN apt-get update && apt-get install -y zerotier-one=1.6.5
 COPY main.sh /var/lib/zerotier-one/main.sh
 


### PR DESCRIPTION
Hi Dmitry,

I find your container very useful, but sadly it doesn't support `arm64`.

First of all, previous keyserver no longer answers, so I've changed it to `keyserver.ubuntu.com`.
Second of all, `frolvlad/alpine-glibc:alpine-3.12_glibc-2.32` doesn't support `arm64` at all. Instead of it, I've used official `alpine` image.