### PR TITLE
Update ZeroTier to 1.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -s "https://raw.githubusercontent.com/zerotier/ZeroTierOne/master/doc/c
 RUN apt-get update && apt-get install -y zerotier-one=1.6.6
 COPY main.sh /var/lib/zerotier-one/main.sh
 
-FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.32
+FROM frolvlad/alpine-glibc:alpine-3.14_glibc-2.33
 
 LABEL version="1.6.6"
 LABEL description="Containerized ZeroTier One for use on CoreOS or other Docker-only Linux hosts."

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ FROM debian:bullseye-slim as builder
 RUN apt-get update && apt-get install -y curl
 RUN curl -s "https://raw.githubusercontent.com/zerotier/ZeroTierOne/master/doc/contact%40zerotier.com.gpg" > /etc/apt/trusted.gpg.d/zerotier.asc && \
     echo "deb http://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list
-RUN apt-get update && apt-get install -y zerotier-one=1.6.5
+RUN apt-get update && apt-get install -y zerotier-one=1.6.6
 COPY main.sh /var/lib/zerotier-one/main.sh
 
 FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.32
 
-LABEL version="1.6.5"
+LABEL version="1.6.6"
 LABEL description="Containerized ZeroTier One for use on CoreOS or other Docker-only Linux hosts."
 
 RUN apk add --update libstdc++

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ## NOTE: to retain configuration; mount a Docker volume, or use a bind-mount, on /var/lib/zerotier-one
 
-FROM debian:buster-slim as builder
+FROM debian:bullseye-slim as builder
 
 ## Supports x86_64, x86, arm, and arm64
 
 RUN apt-get update && apt-get install -y curl gnupg
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0x1657198823e52a61  && \
-    echo "deb http://download.zerotier.com/debian/buster buster main" > /etc/apt/sources.list.d/zerotier.list
+    echo "deb http://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list
 RUN apt-get update && apt-get install -y zerotier-one=1.6.5
 COPY main.sh /var/lib/zerotier-one/main.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM debian:bullseye-slim as builder
 
 ## Supports x86_64, x86, arm, and arm64
 
-RUN apt-get update && apt-get install -y curl gnupg
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0x1657198823e52a61  && \
+RUN apt-get update && apt-get install -y curl
+RUN curl -s "https://raw.githubusercontent.com/zerotier/ZeroTierOne/master/doc/contact%40zerotier.com.gpg" > /etc/apt/trusted.gpg.d/zerotier.asc && \
     echo "deb http://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list
 RUN apt-get update && apt-get install -y zerotier-one=1.6.5
 COPY main.sh /var/lib/zerotier-one/main.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:bullseye-slim as builder
 
 RUN apt-get update && apt-get install -y curl
 RUN curl -s "https://raw.githubusercontent.com/zerotier/ZeroTierOne/master/doc/contact%40zerotier.com.gpg" > /etc/apt/trusted.gpg.d/zerotier.asc && \
-    echo "deb http://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list
+    echo "deb https://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list
 RUN apt-get update && apt-get install -y zerotier-one=1.6.6
 COPY main.sh /var/lib/zerotier-one/main.sh
 


### PR DESCRIPTION
ZeroTier have recently recommended an update to 1.6.6 after including fixes for https://www.zerotier.com/2021/09/21/incident-response-to-september-20th-2021/

Also updates Debian and Alpine versions, removes deprecated apt-key usage and makes all network fetches via HTTPS.